### PR TITLE
Fix DefaultSignatures context for GHC 8.0.2

### DIFF
--- a/src/Control/Monad/Fraxl/Class.hs
+++ b/src/Control/Monad/Fraxl/Class.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 -- Not actually undecidable.
 -- @MonadFraxl f (Fraxl r m)@ is not undecidable,
@@ -37,7 +38,7 @@ import           Data.Vinyl.Types
 class Monad m => MonadFraxl f m where
   -- | 'dataFetch' is used to make a request of type 'f'.
   dataFetch :: f a -> m a
-  default dataFetch :: (MonadTrans t, MonadFraxl f m) => f a -> t m a
+  default dataFetch :: (MonadTrans t, MonadFraxl f n, t n ~ m) => f a -> m a
   dataFetch = lift . dataFetch
 
 instance (Monad m, f ∈ r) => MonadFraxl f (Fraxl r m) where


### PR DESCRIPTION
GHC 8.0.2 fixes some behavior around default signature contexts and as a
result is stricter about the sort of constraints that can be applied to
default signatures [0]. This causes the default dataFetch instances to
fail to unify with messages like:

        Expected type: StateT s m a
          Actual type: StateT s (StateT s m) a

The consensus on that ticket is that the 8.0.2 behavior is correct, and
Simon PJ suggests that default signatures should only ever change the
context of methods, never the structure of the type itself.

This commit fixes the build on 8.0.2 by factoring out the `t m a` into
an equational constraint.

[0] https://ghc.haskell.org/trac/ghc/ticket/12784